### PR TITLE
[untested] Silence notification sound

### DIFF
--- a/.meta.yml
+++ b/.meta.yml
@@ -1,4 +1,6 @@
 icon: "app/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+googleplay: "https://play.google.com/store/apps/details?id=james.metronome"
+package: "james.metronome"
 screenshots:
   - ".github/images/main.png"
   - ".github/images/about.png"

--- a/.meta.yml
+++ b/.meta.yml
@@ -1,0 +1,5 @@
+icon: "app/src/main/res/mipmap-xxxhdpi/ic_launcher.png"
+screenshots:
+  - ".github/images/main.png"
+  - ".github/images/about.png"
+  - ".github/images/theme.png"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,27 @@
 Metronome is a lightweight, well designed metronome app for Android focused on offering a consistent and usable design without limiting functionality.
 
+[![Build Status](https://travis-ci.com/fennifith/Metronome-Android.svg?branch=master)](https://travis-ci.com/fennifith/Metronome-Android)
+[![Discord](https://img.shields.io/discord/514625116706177035.svg?logo=discord&colorB=7289da)](https://discord.gg/kgqJ5hM)
+[![Liberapay](https://img.shields.io/badge/liberapay-donate-yellow.svg?logo=liberapay)](https://liberapay.com/fennifith/donate)
+
+Special thanks to [Kevin Aguilar](https://twitter.com/kevttob) for designing [this app's beautiful icon](https://dribbble.com/shots/5643017-Metronome-Updated-Icon).
+
+## Screenshots
+
 | Home   | About  | Themes |
 |--------|--------|--------|
-|![img](./.github/images/main.png?raw=true)|![img](./.github/images/about.png?raw=true)|![img](./.github/images/theme.png?raw=true)|
+| ![home page](./.github/images/main.png?raw=true) | ![about screen](./.github/images/about.png?raw=true) | ![theming options](./.github/images/theme.png?raw=true) |
+
+## Installation
+
+The app is published on Google Play:
+
+[<img src="https://play.google.com/intl/en_us/badges/images/generic/en_badge_web_generic.png"
+    alt="Get it on Google Play"
+    height="80">](https://play.google.com/store/apps/details?id=james.metronome)
+
+Alternatively, you can download the latest APK from [the GitHub releases](../../releases/).
+
+## Contributing & Build Instructions
+
+Instructions for contributing to this project and building it locally can be found [here](./.github/CONTRIBUTING.md).

--- a/app/src/main/java/james/metronome/services/MetronomeService.java
+++ b/app/src/main/java/james/metronome/services/MetronomeService.java
@@ -125,7 +125,7 @@ public class MetronomeService extends Service implements Runnable {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             ((NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE))
-                    .createNotificationChannel(new NotificationChannel("metronome", getString(R.string.app_name), NotificationManager.IMPORTANCE_DEFAULT));
+                    .createNotificationChannel(new NotificationChannel("metronome", getString(R.string.app_name), NotificationManager.IMPORTANCE_LOW));
 
             builder = new NotificationCompat.Builder(this, "metronome");
         } else


### PR DESCRIPTION
This patch reduces the priority of the metronome start notification to IMPORTANCE_LOW which should silence the notification on metronome start.  If the notification has IMPORTANCE_DEFAULT by design, please ignore and sorry for the bother.  Caveats: I've written a couple of trivial Android apps, but I'm no expert and this patch is completely untested (not even built).